### PR TITLE
Fix Oj error

### DIFF
--- a/lib/attachinary/orm/file_mixin.rb
+++ b/lib/attachinary/orm/file_mixin.rb
@@ -9,7 +9,7 @@ module Attachinary
       base.after_create  :remove_temporary_tag
     end
 
-    def as_json(options)
+    def as_json(options = nil)
       super(only: [:id, :public_id, :format, :version, :resource_type], methods: [:path])
     end
 

--- a/lib/attachinary/version.rb
+++ b/lib/attachinary/version.rb
@@ -1,3 +1,3 @@
 module Attachinary
-  VERSION = "1.4.0"
+  VERSION = "1.4.1"
 end


### PR DESCRIPTION
The Rails 5 method signature for as_json supplies a default nil value, whereas this overwrite does not. This causes issues with Oj json gem, specifically Oj.optimize_rails.